### PR TITLE
Generate APRS beacon based on GPS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Install via libraries:
 - LoRa arduino library: https://github.com/sandeepmistry/arduino-LoRa
 - Arduino Timer library: https://github.com/contrem/arduino-timer
 - CircularBuffer library: https://github.com/rlogiacco/CircularBuffer
+- MicroNMEA: https://github.com/stevemarple/MicroNMEA
+- SparkFun u-blox GNSS Arduino Library
 
 # Software Setup
 - **NB! select next partition scheme for ESP32 in Arduino IDE Tools menu:** "Minimal SPIFFS (1.9 MB APP with OTA/190 KB SPIFFS)"
@@ -104,6 +106,13 @@ Install via libraries:
    - `cfg.EnableRepeater` set to `true` to enable packet repeater
    - `cfg.EnableBeacon` set to `true` to enable periodic beacons specified in `cfg.AprsRawBeacon` with period specified in `cfg.AprsRawBeaconPeriodMinutes` into RF and APRS-IS if `cfg.EnableRfToIs` is enabled
    - `cfg.LoraUseIsr` set to `true` to enable LoRa incoming packet handling using interrupts in continous RX mode suitable for speech data, otherwise set to `false` for single packet polling mode
+
+- GPS APRS BEACON
+   GPS PIN needs to be defined. Following are default T-Beam V1.0 PIN.
+   GPS_RX_PIN 34
+   GPS_TX_PIN 12
+  To use GPS location for APRS beacon, Set CFG_APRS_RAW_BKN to "" empty string. CFG_APRS_SYMBOL_FIRST and CFG_APRS_SYMBOL_SECOND are APRS symbols. Please refer to http://www.aprs.org/symbols/symbols-new.txt for all the symbols. CFG_APRS_COMMENTS will be the APRS Beacon comments. CFG_APRS_BEACONMINUTES will determine how frequently would the beacon be sent. The number is in minutes. 
+  CFG_BEACON need to set to true to send beacons. Beacon will be sent regardless of Client mode or server mode. Beacon will be sent via RF. 
 
 # Protocol Compatibility
 - Make sure LoRa sync word and other LoRa parameters match

--- a/config.h
+++ b/config.h
@@ -5,13 +5,13 @@
 // change pinouts if not defined through native board LORA_* definitions
 #ifndef LORA_RST
 #pragma message("LoRa pin definitions are not found, redefining...")
-#define LORA_RST              26
-#define LORA_IRQ              14
+#define LORA_RST              23
+#define LORA_IRQ              26
 #endif
 
 #ifndef BUILTIN_LED
 #pragma message("BUILDIN_LED is not found, defining as 2")
-#define BUILTIN_LED           2
+#define BUILTIN_LED           25
 #endif
 
 #define CFG_IS_CLIENT_MODE    true
@@ -25,7 +25,7 @@
 #define CFG_LORA_BW           125e3
 #define CFG_LORA_SF           12
 #define CFG_LORA_CR           7
-#define CFG_LORA_PWR          20
+#define CFG_LORA_PWR          100
 #define CFG_LORA_ENABLE_CRC   true  // set to false for speech data
 
 #define CFG_BT_NAME           "loraprs"
@@ -34,9 +34,9 @@
 #define CFG_APRS_PASS         "12345"
 #define CFG_APRS_FILTER	      "r/35.60/139.80/25"
 #define CFG_APRS_RAW_BKN      ""  //set RAW BKN to empty string to utilize GPS
-#define CFG_APRS_SYMBOL_FIRST "L"
-#define CFG_APRS_SYMBOL_SECOND "&"
-#define CFG_APRS_COMMENTS     "LoRA 433.775MHz/BW125/SF12/CR7/0x34"
+#define CFG_APRS_SYMBOL_FIRST "\\"
+#define CFG_APRS_SYMBOL_SECOND "Y"
+#define CFG_APRS_COMMENTS     " LoRA 433.775MHz/BW125/SF12/CR7/0x34"
 #define CFG_APRS_BEACONMINUTES 2
 #define CFG_WIFI_SSID         "<ssid>"
 #define CFG_WIFI_KEY          "<key>"
@@ -59,4 +59,4 @@
 #define GPS_TX_PIN 12
 #define I2C_SDA 21
 #define I2C_SCL 22
-#define GPS_BAND_RATE      9600
+#define GPS_BAND_RATE 9600

--- a/config.h
+++ b/config.h
@@ -30,7 +30,7 @@
 
 #define CFG_BT_NAME           "loraprs"
 
-#define CFG_APRS_LOGIN        "N7DMR-10"
+#define CFG_APRS_LOGIN        "NOCALL-10"
 #define CFG_APRS_PASS         "12345"
 #define CFG_APRS_FILTER	      "r/35.60/139.80/25"
 #define CFG_APRS_RAW_BKN      ""  //set RAW BKN to empty string to utilize GPS

--- a/config.h
+++ b/config.h
@@ -53,10 +53,6 @@
 
 
 //GPS Configuration
-
-#define T_BEAM_V10 
 #define GPS_RX_PIN 34
 #define GPS_TX_PIN 12
-#define I2C_SDA 21
-#define I2C_SCL 22
-#define GPS_BAND_RATE 9600
+#define GPS_BAUD_RATE 9600

--- a/config.h
+++ b/config.h
@@ -30,20 +30,33 @@
 
 #define CFG_BT_NAME           "loraprs"
 
-#define CFG_APRS_LOGIN        "NOCALL-10"
+#define CFG_APRS_LOGIN        "N7DMR-10"
 #define CFG_APRS_PASS         "12345"
 #define CFG_APRS_FILTER	      "r/35.60/139.80/25"
-#define CFG_APRS_RAW_BKN      "NOCALL-10>APZMDM,WIDE1-1:!0000.00N/00000.00E#LoRA 433.775MHz/BW125/SF12/CR7/0x34"
-
+#define CFG_APRS_RAW_BKN      ""  //set RAW BKN to empty string to utilize GPS
+#define CFG_APRS_SYMBOL_FIRST "L"
+#define CFG_APRS_SYMBOL_SECOND "&"
+#define CFG_APRS_COMMENTS     "LoRA 433.775MHz/BW125/SF12/CR7/0x34"
+#define CFG_APRS_BEACONMINUTES 2
 #define CFG_WIFI_SSID         "<ssid>"
 #define CFG_WIFI_KEY          "<key>"
 
 #define CFG_FREQ_CORR         false   // NB! incoming interrupts may stop working on frequent corrections when enabled
 #define CFG_FREQ_CORR_DELTA   1000    //      test with your module before heavy usage
 
-#define CFG_PERSISTENT_APRS   true
+#define CFG_PERSISTENT_APRS   false
 #define CFG_DIGIREPEAT        false
-#define CFG_RF_TO_IS          true
+#define CFG_RF_TO_IS          false
 #define CFG_IS_TO_RF          false
-#define CFG_BEACON            false
-#define CFG_KISS_EXTENSIONS   false
+#define CFG_BEACON            true
+#define CFG_KISS_EXTENSIONS   true
+
+
+//GPS Configuration
+
+#define T_BEAM_V10 
+#define GPS_RX_PIN 34
+#define GPS_TX_PIN 12
+#define I2C_SDA 21
+#define I2C_SCL 22
+#define GPS_BAND_RATE      9600

--- a/config.h
+++ b/config.h
@@ -37,7 +37,7 @@
 #define CFG_APRS_SYMBOL_FIRST "\\"
 #define CFG_APRS_SYMBOL_SECOND "Y"
 #define CFG_APRS_COMMENTS     " LoRA 433.775MHz/BW125/SF12/CR7/0x34"
-#define CFG_APRS_BEACONMINUTES 2
+#define CFG_APRS_BEACONMINUTES 2  // in minutes
 #define CFG_WIFI_SSID         "<ssid>"
 #define CFG_WIFI_KEY          "<key>"
 

--- a/esp32_loraprs.ino
+++ b/esp32_loraprs.ino
@@ -96,7 +96,7 @@ void setup() {
   loraPrsService.setup(config);
   //init GPS
   Serial.println("initGPS");
-  Serial1.begin(GPS_BAND_RATE, SERIAL_8N1, GPS_RX_PIN, GPS_TX_PIN);
+  Serial1.begin(GPS_BAUD_RATE, SERIAL_8N1, GPS_RX_PIN, GPS_TX_PIN);
   delay(1500);
   if (myGNSS.begin(Serial1) == false) {
      Serial.println(F("Ublox GNSS not detected at default I2C address. Please check wiring."));
@@ -113,8 +113,8 @@ bool toggleWatchdogLed(void *) {
   digitalWrite(BUILTIN_LED, !digitalRead(BUILTIN_LED));
   return true;
 }
-
- String create_lat_aprs(double lat) {
+//functions to convert decimal to dms borrowed from https://github.com/lora-aprs/LoRa_APRS_Tracker
+String create_lat_aprs(double lat) {
             char str[20];
             char n_s = 'N';
             if (lat < 0) {
@@ -139,7 +139,6 @@ String create_long_aprs(double lng) {
 }
 
 void setGPSInfo(String arr[]){
-      
       myGNSS.checkUblox(); //See if new data is available. Process bytes as they come in.
       //Get GPS Info
       if (nmea.isValid() == true) {        
@@ -157,7 +156,6 @@ void setGPSInfo(String arr[]){
         arr[1]="0";
     }
 }
-
 
 void SFE_UBLOX_GNSS::processNMEA(char incoming)
   {

--- a/esp32_loraprs.ino
+++ b/esp32_loraprs.ino
@@ -113,21 +113,42 @@ bool toggleWatchdogLed(void *) {
   digitalWrite(BUILTIN_LED, !digitalRead(BUILTIN_LED));
   return true;
 }
+
+ String create_lat_aprs(double lat) {
+            char str[20];
+            char n_s = 'N';
+            if (lat < 0) {
+              n_s = 'S';
+            }
+            lat = std::abs(lat);
+            sprintf(str, "%02d%05.2f%c", (int)lat, (lat - (double)((int)lat)) * 60.0, n_s);
+            String lat_str(str);
+            return lat_str;
+}
+
+String create_long_aprs(double lng) {
+      char str[20];
+      char e_w = 'E';
+      if (lng < 0) {
+        e_w = 'W';
+      }
+      lng = std::abs(lng);
+      sprintf(str, "%03d%05.2f%c", (int)lng, (lng - (double)((int)lng)) * 60.0, e_w);
+      String lng_str(str);
+      return lng_str;
+}
+
 void setGPSInfo(String arr[]){
       
       myGNSS.checkUblox(); //See if new data is available. Process bytes as they come in.
       //Get GPS Info
-      if (nmea.isValid() == true) {
-        float latitude_mdeg = nmea.getLatitude() / 10000.;
-        float longitude_mdeg = nmea.getLongitude() / 10000.;
-        String latitude1 =  (latitude_mdeg > 0) ? String(latitude_mdeg)+"N" : String(latitude_mdeg)+"S";
-        String longitude1 = (longitude_mdeg > 0) ? String(longitude_mdeg)+"E" : String(fabs(longitude_mdeg))+"W";
-        arr[0]=latitude1;
-        arr[1]=longitude1;
+      if (nmea.isValid() == true) {        
+        arr[0]=create_lat_aprs((double)nmea.getLatitude()/1000000);
+        arr[1]=create_long_aprs((double)nmea.getLongitude()/1000000);
         Serial.print("Latitude (deg): ");
         Serial.println(arr[0]);
         Serial.print("Longitude (deg): ");
-        Serial.println(arr[1]);
+       Serial.println(arr[1]);
     } else {
         Serial.print("No Fix - ");
         Serial.print("Num. satellites: ");

--- a/esp32_loraprs.ino
+++ b/esp32_loraprs.ino
@@ -2,7 +2,6 @@
 #include <u-blox_config_keys.h>
 #include <u-blox_structs.h>
 
-#include <SPI.h>
 #include <arduino-timer.h>
 #include "WiFi.h"
 #include "loraprs_service.h"

--- a/esp32_loraprs.ino
+++ b/esp32_loraprs.ino
@@ -1,3 +1,7 @@
+#include <SparkFun_u-blox_GNSS_Arduino_Library.h>
+#include <u-blox_config_keys.h>
+#include <u-blox_structs.h>
+
 #include <arduino-timer.h>
 #include "WiFi.h"
 #include "loraprs_service.h"

--- a/loraprs_config.h
+++ b/loraprs_config.h
@@ -42,7 +42,10 @@ struct Config
   String AprsFilter;    // aprs filter, see http://www.aprs-is.net/javAPRSFilter.aspx, do not include filter directive, just space separated values
   String AprsRawBeacon; // aprs string for server beacon, e.g. NOCALL-1>APZMDM,WIDE1-1:!0000.00N/00000.00E#LoRA 433.775MHz/BW125/SF12/CR7/0xf3
   int AprsRawBeaconPeriodMinutes; // aprs beacon period
-
+  String AprsSymbolFirst;
+  String AprsSymbolSecond;
+  String AprsComments;
+  
   // frequency correction
   bool EnableAutoFreqCorrection;        // true - correct own frequency based on received packet frequency deviation
   int AutoFreqCorrectionDeltaHz;        // correct when difference is larger than this value

--- a/loraprs_service.cpp
+++ b/loraprs_service.cpp
@@ -1,5 +1,5 @@
 #include "loraprs_service.h"
-
+void setGPSInfo();
 namespace LoraPrs {
   
 Service::Service()
@@ -204,6 +204,7 @@ void Service::sendPeriodicBeacon()
   long currentMs = millis();
 
   if (previousBeaconMs_ == 0 || currentMs - previousBeaconMs_ >= config_.AprsRawBeaconPeriodMinutes * 60 * 1000) {
+      ::setGPSInfo();
       AX25::Payload payload(config_.AprsRawBeacon);
       if (payload.IsValid()) {
         sendAX25ToLora(payload);

--- a/loraprs_service.h
+++ b/loraprs_service.h
@@ -46,7 +46,7 @@ private:
   }
   inline bool needsWifi() const { return needsAprsis(); }
   inline bool needsBt() const { return config_.IsClientMode; }
-  inline bool needsBeacon() const { return !config_.IsClientMode && config_.EnableBeacon; }
+  inline bool needsBeacon() const { return config_.EnableBeacon; }
 
 protected:
   virtual bool onRigTxBegin();


### PR DESCRIPTION
Functional Add:
Generate APRS beacon from onboard GPS signal

Added Dependencies:
- MicroNMEA: https://github.com/stevemarple/MicroNMEA
- SparkFun u-blox GNSS Arduino Library

Behavior Change:
* APRS Beacon will be sent as long as CFG_BEACON is true regardless of client mode or not. 
* If CFG_APRS_RAW_BKN is set to blank string, it will utilize GPS to generate APRS string. If not, it will take what's in the RAW_BKN.
* GPS RX/TX PIN need to be configured based on your board.

Added Configuration
#define CFG_APRS_SYMBOL_FIRST ""
#define CFG_APRS_SYMBOL_SECOND ""
#define CFG_APRS_COMMENTS     "  "
#define CFG_APRS_BEACONMINUTES 2  // in minutes
#define GPS_RX_PIN 34   //GPS RX PIN
#define GPS_TX_PIN 12  //GPS TX PIN
#define GPS_BAUD_RATE 9600  //GPS BAUD RATE

Comments:
CFG_APRS_LOGIN is used as the callsign to generate APRS string. 
